### PR TITLE
Fix error "Class extends value undefined is not a constructor or null"

### DIFF
--- a/event.js
+++ b/event.js
@@ -24,4 +24,4 @@ class Event {
   }
 }
 
-module.exports = Event;
+module.exports = { Event };


### PR DESCRIPTION
Fix'ed event error

class new_chat_membersEvent extends Event {
                                    ^

TypeError: Class extends value undefined is not a constructor or null